### PR TITLE
Convert operating_area column to PostGIS geometry for better performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,7 @@
 source "https://rubygems.org"
 
 ruby "3.4.1"
-ruby "3.4.1"
 gem "rails", "~> 8.0.1"
-
-gem "pg"
-gem "activerecord-postgis-adapter"
 
 gem "pg"
 gem "activerecord-postgis-adapter"
@@ -29,10 +25,6 @@ group :development, :test do
   gem "brakeman", require: false
 
   gem "rubocop-rails-omakase", require: false
-  gem "rspec-rails"
-  gem "factory_bot_rails"
-  gem "faker"
-  gem "rspec-json_expectations"
   gem "rspec-rails"
   gem "factory_bot_rails"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,6 @@ GEM
     activerecord-postgis-adapter (11.0.0)
       activerecord (~> 8.0.0)
       rgeo-activerecord (~> 8.0.0)
-    activerecord-postgis-adapter (11.0.0)
-      activerecord (~> 8.0.0)
-      rgeo-activerecord (~> 8.0.0)
     activestorage (8.0.1)
       actionpack (= 8.0.1)
       activejob (= 8.0.1)
@@ -95,30 +92,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.0)
-    diff-lcs (1.6.0)
     drb (2.2.1)
-    dry-core (1.1.0)
-      concurrent-ruby (~> 1.0)
-      logger
-      zeitwerk (~> 2.6)
-    dry-inflector (1.2.0)
-    dry-logic (1.6.0)
-      bigdecimal
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 1.1)
-      zeitwerk (~> 2.6)
-    dry-struct (1.7.1)
-      dry-core (~> 1.1)
-      dry-types (~> 1.8, >= 1.8.2)
-      ice_nine (~> 0.11)
-      zeitwerk (~> 2.6)
-    dry-types (1.8.2)
-      bigdecimal (~> 3.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 1.0)
-      dry-inflector (~> 1.0)
-      dry-logic (~> 1.4)
-      zeitwerk (~> 2.6)
     dry-core (1.1.0)
       concurrent-ruby (~> 1.0)
       logger
@@ -149,19 +123,11 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    factory_bot (6.5.1)
-      activesupport (>= 6.1.0)
-    factory_bot_rails (6.4.4)
-      factory_bot (~> 6.5)
-      railties (>= 5.0.0)
-    faker (3.5.1)
-      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hana (1.3.7)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     ice_nine (0.11.2)
     io-console (0.8.0)
     irb (1.15.1)
@@ -176,18 +142,6 @@ GEM
       simpleidn (~> 0.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
-    kaminari (1.2.2)
-      activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.2.2)
-      kaminari-activerecord (= 1.2.2)
-      kaminari-core (= 1.2.2)
-    kaminari-actionview (1.2.2)
-      actionview
-      kaminari-core (= 1.2.2)
-    kaminari-activerecord (1.2.2)
-      activerecord
-      kaminari-core (= 1.2.2)
-    kaminari-core (1.2.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -254,7 +208,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -265,8 +218,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.10)
-    rack-attack (6.7.0)
-      rack (>= 1.0, < 4)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-session (2.1.0)
@@ -307,10 +258,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    ransack (4.3.0)
-      activerecord (>= 6.1.5)
-      activesupport (>= 6.1.5)
-      i18n
     ransack (4.3.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
@@ -407,12 +354,9 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter
-  activerecord-postgis-adapter
   bootsnap
   brakeman
   debug
-  dry-struct
-  dry-types
   dry-struct
   dry-types
   factory_bot_rails
@@ -424,17 +368,12 @@ DEPENDENCIES
   pg
   puma (>= 5.0)
   rack-attack
-  rack-attack
   rails (~> 8.0.1)
-  ransack
   ransack
   rspec-json_expectations
   rspec-rails
   rswag-ui
   rubocop-rails-omakase
-
-RUBY VERSION
-   ruby 3.4.1p0
 
 RUBY VERSION
    ruby 3.4.1p0

--- a/app/utils/geo_helper.rb
+++ b/app/utils/geo_helper.rb
@@ -1,8 +1,11 @@
 module GeoHelper
   class << self
     def operating_area(address, operating_radius)
-      factory = RGeo::Geographic.spherical_factory(srid: 4326)
-      factory.point(address.location.x, address.location.y).buffer(operating_radius)
+      sql = ActiveRecord::Base.sanitize_sql([ <<-SQL.squish, address.location.x, address.location.y, operating_radius ])
+        SELECT ST_Buffer(ST_MakePoint(?, ?)::geography, ?);
+      SQL
+
+      ActiveRecord::Base.connection.select_value(sql)
     end
   end
 end

--- a/db/migrate/20250220070009_change_operating_area_to_geometry.rb
+++ b/db/migrate/20250220070009_change_operating_area_to_geometry.rb
@@ -1,0 +1,31 @@
+class ChangeOperatingAreaToGeometry < ActiveRecord::Migration[8.0]
+  def up
+    remove_index :partners, :operating_area
+    remove_column :partners, :operating_area
+
+    add_column :partners, :operating_area, :geometry, limit: { srid: 4326, type: "geometry" }
+    add_index :partners, :operating_area, using: :gist
+
+    execute <<-SQL.squish
+      UPDATE partners
+      SET operating_area = ST_Buffer(
+          ST_SetSRID(
+            ST_MakePoint(
+                ST_X(addresses.location::geometry),
+                ST_Y(addresses.location::geometry)
+            ),
+            4326
+          ),
+          operating_radius
+        )
+        FROM addresses
+        WHERE partners.address_id = addresses.id;
+      SQL
+
+    change_column_null :partners, :operating_area, false
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reversed"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_15_114412) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_20_070009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -40,11 +40,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_15_114412) do
   create_table "partners", force: :cascade do |t|
     t.string "full_name", null: false
     t.integer "operating_radius", null: false
-    t.geography "operating_area", limit: {srid: 4326, type: "st_polygon", geographic: true}, null: false
     t.decimal "rating", precision: 3, scale: 2, default: "0.0", null: false
     t.bigint "address_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.geometry "operating_area", limit: {srid: 4326, type: "geometry"}, null: false
     t.index ["address_id"], name: "index_partners_on_address_id"
     t.index ["operating_area"], name: "index_partners_on_operating_area", using: :gist
     t.index ["rating"], name: "index_partners_on_rating"


### PR DESCRIPTION
* Fixed performance issue in partners search request. Changed precomputed `operating_area` from postgis _geography_ to _geometry_
* Fixed merging issues in Gemfile

## How to apply the fix

Just run `rake db:migrate`. If you use containerized setup then there are 2 options:

```sh
make shell
rake db:migrate
```

or use a shortcut for that
```sh
make run-app rake db:migrate
```